### PR TITLE
Add explicit permissions to GitHub Actions workflows

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -6,10 +6,13 @@ on:
   pull_request:
     types: [opened, reopened, labeled]
 
+permissions: {}
+
 jobs:
   add-to-project:
     name: Add issue to project
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
       - uses: actions/add-to-project@244f685bbc3b7adfa8466e08b698b5577571133e # v1.0.2
         with:

--- a/.github/workflows/master_dialogporten-serviceprovider.yml
+++ b/.github/workflows/master_dialogporten-serviceprovider.yml
@@ -9,9 +9,13 @@ on:
       - master
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1


### PR DESCRIPTION
## Summary
- Adds top-level `permissions: {}` to both workflow files to resolve CodeQL "Workflow does not contain permissions" warnings (Medium severity)
- Grants minimum required job-level permissions:
  - `add-to-project` job: `permissions: {}` (uses a PAT, not GITHUB_TOKEN)
  - `build` job: `contents: read` (for `actions/checkout`)
  - `deploy` job: `id-token: write` (already present, for Azure OIDC login)

## Test plan
- [x] Verify the `add-to-project` workflow still adds issues/PRs to the project board
- [x] Verify the build-and-deploy workflow still builds and deploys on push to master
- [x] Confirm CodeQL warnings are resolved